### PR TITLE
Updated test_helper.rb to resolve errors when running `rails test`

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -13,7 +13,7 @@ require 'contexts'
 require 'shoulda/matchers'
 
 class ActiveSupport::TestCase
-  ActiveRecord::Migration.check_pending!
+  # ActiveRecord::Migration.check_pending!
 
   # include the Contexts module for all tests
   include Contexts
@@ -25,7 +25,7 @@ class ActiveSupport::TestCase
   #
   # Note: You'll currently still have to declare fixtures explicitly in integration tests
   # -- they do not yet inherit this setting
-  fixtures :all
+  # fixtures :all
 
   # Add more helper methods to be used by all tests here...
   # Prof. H's helper method to increase readability


### PR DESCRIPTION
The original starter repo had an error, `undefined method 'check_pending!' for an instance of ActiveRecord::Migration (NoMethodError)` pop up when running `rails test`. After some research, this is because Rails 8 removed this method, which is included in `test_helper.rb`. Commenting out this line should suffice to allow the tests to be able to run.

Additionally, the original `test_helper.rb` contains a line `fixtures :all`, which is uncommented. This results in failing scopes tests as the content from the fixtures e.g. "MyString" is also added to the Contexts during test runtime. Commenting this line out removes the import of the fixtures, ensuring the test environment only uses the Contexts module for test objects.